### PR TITLE
docs: explain how Konsist and ArchUnit work and compare them

### DIFF
--- a/examples/archunit/README.md
+++ b/examples/archunit/README.md
@@ -7,10 +7,51 @@ This module demonstrates how to use [ArchUnit](https://www.archunit.org/) to enf
 ArchUnit is a free, simple, and extensible library for checking the architecture of your Java or Kotlin code. It lets you define architecture rules as code, which are then verified during test execution. This ensures that your codebase adheres to your architectural decisions and prevents architectural drift over time.
 
 Key benefits:
+
 - Define architecture rules as readable code
 - Catch architectural violations early in the development process
 - Integrate with your existing test suite (JUnit)
 - No runtime dependencies in production code
+
+## ⚙️ How It Works
+
+ArchUnit analyzes your **compiled bytecode**. It reads the `.class` files via its
+`ClassFileImporter` (see the test classes in this module) and builds a graph of classes,
+methods, fields, annotations and — crucially — the **actual dependencies** between them.
+Rules are expressed as fluent assertions (`ArchRuleDefinition`, `layeredArchitecture()`)
+over that imported graph.
+
+Because it works on the **bytecode**, not on the source:
+
+- ✅ It resolves the _real_ dependency graph: method calls, field accesses, inheritance
+  and annotation usage — even ones that are not obvious from a single source file.
+- ✅ It is **language-agnostic on the JVM**: it checks Java and Kotlin (and any other JVM
+  language) uniformly, which makes it a good fit for mixed-language codebases.
+- ⚠️ The code must be **compiled first** — rules run as part of the test phase, after
+  `.class` files exist.
+- ⚠️ It cannot see source-only details that are erased or transformed by the Kotlin
+  compiler: top-level functions become synthetic `…Kt` classes, type aliases disappear,
+  KDoc and source declaration order are gone.
+
+> 🔁 For a source-based alternative that understands Kotlin-specific constructs without
+> compiling, see the sibling [`konsist`](../konsist/README.md) module.
+
+## 🔍 ArchUnit vs. Konsist — at a glance
+
+| Aspect                                                                                    | **ArchUnit** (this module)                               | **Konsist** ([sibling](../konsist/README.md)) |
+| ----------------------------------------------------------------------------------------- | -------------------------------------------------------- | --------------------------------------------- |
+| Analysis target                                                                           | Compiled **bytecode** (`.class` via `ClassFileImporter`) | Kotlin **source code** (AST/PSI)              |
+| Needs compilation first                                                                   | ✅ Yes                                                   | ❌ No                                         |
+| Languages                                                                                 | Any JVM language (Java **and** Kotlin)                   | Kotlin only                                   |
+| Real call- & field-level dependency graph                                                 | ✅ Full (resolved from bytecode)                         | ⚠️ Limited (declared references)              |
+| Kotlin source constructs (top-level funcs, type aliases, KDoc, declaration order, naming) | ⚠️ Limited / erased after compilation                    | ✅ First-class                                |
+| Layer / dependency rules                                                                  | ✅ `layeredArchitecture()`                               | ✅ `assertArchitecture { … }`                 |
+| Custom rules                                                                              | Custom `ArchCondition` classes                           | Lambdas over declarations                     |
+
+**Rule of thumb:** reach for **ArchUnit** when your rules are about _what the compiled
+code actually depends on_, or when you need to cover Java as well; reach for **Konsist**
+when your rules are about _how the Kotlin source is written_ (style, naming, file
+structure, Kotlin-specific declarations).
 
 ## 🔧 Available Tests
 
@@ -19,6 +60,7 @@ This module provides two main abstract test classes that you can extend in your 
 ### 1. BasicCodingGuidelinesTest
 
 Enforces basic coding guidelines:
+
 - Ensures all classes have proper package declarations
 - Verifies that classes are free of circular dependencies
 
@@ -29,6 +71,7 @@ class YourBasicCodingGuidelinesTest : BasicCodingGuidelinesTest("com.yourcompany
 ### 2. HexagonalArchitectureTest
 
 Enforces rules specific to hexagonal (ports and adapters) architecture:
+
 - Verifies layer separation and dependencies
 - Ensures ports are defined as interfaces
 - Checks that application services implement exactly one use case

--- a/examples/konsist/README.md
+++ b/examples/konsist/README.md
@@ -7,11 +7,50 @@ This module demonstrates how to use [Konsist](https://github.com/LemonAppDev/kon
 Konsist is a free, Kotlin-focused library for checking the architecture of your code. It lets you define architecture rules as Kotlin code, which are then verified during test execution. This ensures that your codebase adheres to your architectural decisions and prevents architectural drift over time.
 
 Key benefits:
+
 - Define architecture rules as readable Kotlin code
 - Catch architectural violations early in the development process
 - Integrate with your existing test suite (JUnit)
 - Kotlin-first approach with idiomatic API
 - No runtime dependencies in production code
+
+## ⚙️ How It Works
+
+Konsist analyzes your **Kotlin source code** directly. Under the hood it parses the
+`.kt` files via the Kotlin compiler and exposes the resulting syntax tree (AST/PSI) as
+a Kotlin-friendly declaration API (`KoClassDeclaration`, `KoFunctionDeclaration`,
+`KoPropertyDeclaration`, …). You navigate these declarations and assert on them — see
+`scopeFromProject()` / `scopeFromPackage(...)` in the test classes of this module.
+
+Because it works on the **source**, not on compiled output:
+
+- ✅ No compilation step is required — rules run against the raw `.kt` files.
+- ✅ It understands Kotlin-only constructs: top-level functions, extension functions,
+  type aliases, `data`/`sealed`/`value` modifiers, KDoc, declaration order, visibility,
+  file & naming conventions.
+- ⚠️ It is **Kotlin-only** — it cannot see Java source or third-party `.class` files.
+- ⚠️ It reasons about _declared_ references in the source, not the fully resolved
+  runtime call graph, so deep transitive call-level dependency analysis is limited.
+
+> 🔁 For a bytecode-based alternative that also covers Java and resolves real call-level
+> dependencies, see the sibling [`archunit`](../archunit/README.md) module.
+
+## 🔍 Konsist vs. ArchUnit — at a glance
+
+| Aspect                                                                                    | **Konsist** (this module)        | **ArchUnit** ([sibling](../archunit/README.md))          |
+| ----------------------------------------------------------------------------------------- | -------------------------------- | -------------------------------------------------------- |
+| Analysis target                                                                           | Kotlin **source code** (AST/PSI) | Compiled **bytecode** (`.class` via `ClassFileImporter`) |
+| Needs compilation first                                                                   | ❌ No                            | ✅ Yes                                                   |
+| Languages                                                                                 | Kotlin only                      | Any JVM language (Java **and** Kotlin)                   |
+| Kotlin source constructs (top-level funcs, type aliases, KDoc, declaration order, naming) | ✅ First-class                   | ⚠️ Limited / erased after compilation                    |
+| Real call- & field-level dependency graph                                                 | ⚠️ Limited (declared references) | ✅ Full (resolved from bytecode)                         |
+| Layer / dependency rules                                                                  | ✅ `assertArchitecture { … }`    | ✅ `layeredArchitecture()`                               |
+| Custom rules                                                                              | Lambdas over declarations        | Custom `ArchCondition` classes                           |
+
+**Rule of thumb:** reach for **Konsist** when your rules are about _how the Kotlin source
+is written_ (style, naming, file structure, Kotlin-specific declarations); reach for
+**ArchUnit** when your rules are about _what the compiled code actually depends on_, or
+when you need to cover Java as well.
 
 ## 🔧 Available Tests
 
@@ -20,6 +59,7 @@ This module provides two main abstract test classes that you can extend in your 
 ### 1. BasicCodingGuidelinesTest
 
 Enforces basic coding guidelines:
+
 - Ensures all classes have proper package declarations
 - Prevents wildcard imports (except for java.util)
 
@@ -30,6 +70,7 @@ class YourBasicCodingGuidelinesTest : BasicCodingGuidelinesTest("com.yourcompany
 ### 2. HexagonalArchitectureTest
 
 Enforces rules specific to hexagonal (ports and adapters) architecture:
+
 - Verifies layer separation and dependencies
 - Ensures ports are defined as interfaces
 - Checks that application services implement exactly one use case


### PR DESCRIPTION
## Summary

Reworks the two example READMEs so a reader can quickly understand **how each tool works** and **how they differ**.

- **`examples/konsist/README.md`** and **`examples/archunit/README.md`** each gain a compact **⚙️ How It Works** section:
  - **Konsist** analyzes **Kotlin source code** (AST/PSI via the Kotlin compiler, `scopeFromProject()`) — no compilation needed, understands Kotlin-only constructs (top-level/extension functions, type aliases, KDoc, declaration order), Kotlin-only, limited call-graph depth.
  - **ArchUnit** analyzes **compiled bytecode** (`.class` via `ClassFileImporter`) — needs compilation, resolves the real method-/field-level dependency graph, covers Java + Kotlin, but cannot see source-only details erased by the compiler.
- A **🔍 side-by-side comparison table** in both files (each from its own perspective) plus a "rule of thumb" and cross-links between the modules.

## Why

The two READMEs were near-identical boilerplate and didn't explain the fundamental bytecode-vs-source distinction, which is the main thing that decides which tool fits a given rule.

## Notes

- Claims verified against the actual module code (`ClassFileImporter` vs. `Konsist.scopeFromProject()`).
- `prettier --write` applied to both files.