### PR TITLE
build(deps): upgrade to Spring Boot 4.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .gradle
 **/build/
 .DS_Store
+.claude/logs/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,8 +34,6 @@ tasks.getByName<BootJar>("bootJar") {
     enabled = false
 }
 
-// Captured here because the type-safe `libs` accessor is only available in the
-// root build script scope, not inside the `subprojects { }` configuration closure.
 val springBootBom = libs.spring.boot.bom
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.springframework)
-    alias(libs.plugins.spring.dependency)
     alias(libs.plugins.ktlint)
 }
 
@@ -35,6 +34,10 @@ tasks.getByName<BootJar>("bootJar") {
     enabled = false
 }
 
+// Captured here because the type-safe `libs` accessor is only available in the
+// root build script scope, not inside the `subprojects { }` configuration closure.
+val springBootBom = libs.spring.boot.bom
+
 subprojects {
 
     println("Enabling JVM plugin in project ${project.name}...")
@@ -43,8 +46,11 @@ subprojects {
     println("Enabling Kotlin Spring plugin in project ${project.name}...")
     apply(plugin = "org.jetbrains.kotlin.plugin.spring")
 
-    println("Enabling Spring Boot Dependency Management in project ${project.name}...")
-    apply(plugin = "io.spring.dependency-management")
+    println("Importing the Spring Boot BOM as a Gradle platform in project ${project.name}...")
+    dependencies {
+        "implementation"(platform(springBootBom))
+        "testImplementation"(platform(springBootBom))
+    }
 
     println("Enabling ktLint plugin in project ${project.name}...")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")

--- a/examples/spring-for-graphql-fragment-source/build.gradle.kts
+++ b/examples/spring-for-graphql-fragment-source/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(libs.bundles.graphql)
     testImplementation(libs.bundles.test)
     testImplementation(libs.spring.graphql.test)
+    testImplementation(libs.spring.boot.graphql.test)
     testImplementation(project(":examples:archunit"))
     testImplementation(project(":examples:konsist"))
 }

--- a/examples/spring-for-graphql-fragment-source/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/LoadTasksController.kt
+++ b/examples/spring-for-graphql-fragment-source/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/LoadTasksController.kt
@@ -2,7 +2,7 @@ package de.emaarco.example.adapter.inbound.graphql
 
 import de.emaarco.example.adapter.inbound.shared.TaskDto
 import de.emaarco.example.application.port.inbound.LoadTasksQuery
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.graphql.data.method.annotation.QueryMapping
 import org.springframework.stereotype.Controller
 

--- a/examples/spring-for-graphql-fragment-source/src/main/kotlin/de/emaarco/example/adapter/inbound/spring/TaskDataSink.kt
+++ b/examples/spring-for-graphql-fragment-source/src/main/kotlin/de/emaarco/example/adapter/inbound/spring/TaskDataSink.kt
@@ -2,8 +2,8 @@ package de.emaarco.example.adapter.inbound.spring
 
 import de.emaarco.example.adapter.inbound.shared.TaskInput
 import de.emaarco.example.application.port.inbound.AddTaskUseCase
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.annotation.PostConstruct
-import mu.KotlinLogging
 import org.springframework.stereotype.Component
 
 /**

--- a/examples/spring-for-graphql-fragment-source/src/main/kotlin/de/emaarco/example/application/service/AddTaskService.kt
+++ b/examples/spring-for-graphql-fragment-source/src/main/kotlin/de/emaarco/example/application/service/AddTaskService.kt
@@ -3,7 +3,7 @@ package de.emaarco.example.application.service
 import de.emaarco.example.application.port.inbound.AddTaskUseCase
 import de.emaarco.example.application.port.outbound.TaskRepository
 import de.emaarco.example.domain.Task
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 
 @Service

--- a/examples/spring-for-graphql-fragment-source/src/test/kotlin/de/emaarco/example/adapter/inbound/graphql/GraphQlTestConfiguration.kt
+++ b/examples/spring-for-graphql-fragment-source/src/test/kotlin/de/emaarco/example/adapter/inbound/graphql/GraphQlTestConfiguration.kt
@@ -9,8 +9,8 @@ import org.springframework.graphql.support.DocumentSource
 import org.springframework.graphql.support.ResourceDocumentSource
 import org.springframework.graphql.test.tester.ExecutionGraphQlServiceTester
 import org.springframework.graphql.test.tester.GraphQlTester
-import org.springframework.http.codec.json.Jackson2JsonDecoder
-import org.springframework.http.codec.json.Jackson2JsonEncoder
+import org.springframework.http.codec.json.JacksonJsonDecoder
+import org.springframework.http.codec.json.JacksonJsonEncoder
 
 @Configuration
 class GraphQlTestConfiguration {
@@ -22,8 +22,8 @@ class GraphQlTestConfiguration {
         return ExecutionGraphQlServiceTester
             .builder(executionGraphQlTester)
             .documentSource(customDocumentSource)
-            .encoder(Jackson2JsonEncoder())
-            .decoder(Jackson2JsonDecoder())
+            .encoder(JacksonJsonEncoder())
+            .decoder(JacksonJsonDecoder())
             .build()
     }
 

--- a/examples/spring-for-graphql-fragment-source/src/test/kotlin/de/emaarco/example/adapter/inbound/graphql/LoadTasksControllerTest.kt
+++ b/examples/spring-for-graphql-fragment-source/src/test/kotlin/de/emaarco/example/adapter/inbound/graphql/LoadTasksControllerTest.kt
@@ -13,7 +13,7 @@ import io.mockk.every
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.graphql.GraphQlTest
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
 import org.springframework.context.annotation.Import
 import org.springframework.graphql.test.tester.GraphQlTester
 import java.util.*

--- a/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/AddTaskController.kt
+++ b/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/AddTaskController.kt
@@ -4,7 +4,7 @@ import de.emaarco.example.adapter.inbound.shared.CustomRequestHeaders.X_USER_ID
 import de.emaarco.example.adapter.inbound.shared.TaskDto
 import de.emaarco.example.adapter.inbound.shared.TaskInput
 import de.emaarco.example.application.port.inbound.AddTaskUseCase
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.ContextValue
 import org.springframework.graphql.data.method.annotation.MutationMapping

--- a/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/CompleteTaskController.kt
+++ b/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/CompleteTaskController.kt
@@ -3,7 +3,7 @@ package de.emaarco.example.adapter.inbound.graphql
 import de.emaarco.example.adapter.inbound.shared.TaskDto
 import de.emaarco.example.application.port.inbound.CompleteTaskUseCase
 import de.emaarco.example.domain.TaskId
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.MutationMapping
 import org.springframework.stereotype.Controller

--- a/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/DeleteTaskController.kt
+++ b/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/DeleteTaskController.kt
@@ -2,7 +2,7 @@ package de.emaarco.example.adapter.inbound.graphql
 
 import de.emaarco.example.application.port.inbound.DeleteTaskUseCase
 import de.emaarco.example.domain.TaskId
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.MutationMapping
 import org.springframework.stereotype.Controller

--- a/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/LoadTasksController.kt
+++ b/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/LoadTasksController.kt
@@ -2,7 +2,7 @@ package de.emaarco.example.adapter.inbound.graphql
 
 import de.emaarco.example.adapter.inbound.shared.TaskDto
 import de.emaarco.example.application.port.inbound.LoadTasksQuery
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.graphql.data.method.annotation.QueryMapping
 import org.springframework.stereotype.Controller
 

--- a/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/UpdateTaskController.kt
+++ b/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/UpdateTaskController.kt
@@ -4,7 +4,7 @@ import de.emaarco.example.adapter.inbound.shared.TaskDto
 import de.emaarco.example.adapter.inbound.shared.TaskInput
 import de.emaarco.example.application.port.inbound.UpdateTaskUseCase
 import de.emaarco.example.domain.TaskId
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.MutationMapping
 import org.springframework.stereotype.Controller

--- a/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/interceptor/GraphQlRequestHeaderInterceptor.kt
+++ b/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/interceptor/GraphQlRequestHeaderInterceptor.kt
@@ -28,8 +28,7 @@ class GraphQlRequestHeaderInterceptor(
         return chain.next(request)
     }
 
-    private fun getHeadersFromRequest(request: WebGraphQlRequest): Map<String, Any> =
-        request.headers.mapValues { it.value.first() }
+    private fun getHeadersFromRequest(request: WebGraphQlRequest): Map<String, Any> = request.headers.toSingleValueMap()
 
     private fun addHeadersToGraphQLContext(
         request: WebGraphQlRequest,

--- a/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/interceptor/GraphQlRequestHeaderInterceptor.kt
+++ b/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/graphql/interceptor/GraphQlRequestHeaderInterceptor.kt
@@ -1,7 +1,7 @@
 package de.emaarco.example.adapter.inbound.graphql.interceptor
 
-import mu.KLogger
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.graphql.server.WebGraphQlInterceptor
 import org.springframework.graphql.server.WebGraphQlInterceptor.Chain
 import org.springframework.graphql.server.WebGraphQlRequest

--- a/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/rest/AddTaskRestController.kt
+++ b/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/adapter/inbound/rest/AddTaskRestController.kt
@@ -4,7 +4,7 @@ import de.emaarco.example.adapter.inbound.shared.CustomRequestHeaders.X_USER_ID
 import de.emaarco.example.adapter.inbound.shared.TaskDto
 import de.emaarco.example.adapter.inbound.shared.TaskInput
 import de.emaarco.example.application.port.inbound.AddTaskUseCase
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader

--- a/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/application/service/AddTaskService.kt
+++ b/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/application/service/AddTaskService.kt
@@ -3,7 +3,7 @@ package de.emaarco.example.application.service
 import de.emaarco.example.application.port.inbound.AddTaskUseCase
 import de.emaarco.example.application.port.outbound.TaskRepository
 import de.emaarco.example.domain.Task
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 
 @Service

--- a/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/application/service/CompleteTaskService.kt
+++ b/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/application/service/CompleteTaskService.kt
@@ -4,7 +4,7 @@ import de.emaarco.example.application.port.inbound.CompleteTaskUseCase
 import de.emaarco.example.application.port.outbound.TaskRepository
 import de.emaarco.example.domain.Task
 import de.emaarco.example.domain.TaskId
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 
 @Service

--- a/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/application/service/DeleteTaskService.kt
+++ b/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/application/service/DeleteTaskService.kt
@@ -3,7 +3,7 @@ package de.emaarco.example.application.service
 import de.emaarco.example.application.port.inbound.DeleteTaskUseCase
 import de.emaarco.example.application.port.outbound.TaskRepository
 import de.emaarco.example.domain.TaskId
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 
 @Service

--- a/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/application/service/UpdateTaskService.kt
+++ b/examples/spring-for-graphql-http-headers/src/main/kotlin/de/emaarco/example/application/service/UpdateTaskService.kt
@@ -3,7 +3,7 @@ package de.emaarco.example.application.service
 import de.emaarco.example.application.port.inbound.UpdateTaskUseCase
 import de.emaarco.example.application.port.outbound.TaskRepository
 import de.emaarco.example.domain.Task
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 
 @Service

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,5 @@
 [versions]
 spring_version = "4.1.0"
-# Kept separate from spring_version so Dependabot can bump the plugin
-# independently of the library modules (see dependabot-core#6990).
 spring_boot_plugin_version = "4.1.0"
 mockk_version = "1.14.11"
 spring_mockk_version = "5.0.1"
@@ -21,8 +19,6 @@ webflux = { module = "org.springframework.boot:spring-boot-starter-webflux", ver
 aop = { module = "org.springframework.boot:spring-boot-starter-aspectj", version.ref = "spring_version" }
 actuator = { module = "org.springframework.boot:spring-boot-starter-actuator", version.ref = "spring_version" }
 devtools = { module = "org.springframework.boot:spring-boot-devtools", version.ref = "spring_version" }
-
-# Spring Boot BOM, imported as a Gradle platform (replaces io.spring.dependency-management)
 spring_boot_bom = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring_version" }
 
 # Tests

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-spring_version = "3.5.16"
+spring_version = "4.1.0"
 spring_dependency_version = "1.1.7"
 mockk_version = "1.14.11"
 spring_mockk_version = "5.0.1"
 spring_graphql_test_version = "2.0.4"
 kotlin_version = "2.4.0"
 kotlin_logging_version = "3.0.5"
-mockito_version = "5.2.0"
+mockito_version = "5.23.0"
 archunit_version = "1.4.2"
 kotlin_mockito_version = "6.3.0"
 ktlint_gradle_version = "14.2.0"
@@ -16,14 +16,15 @@ konsist_version = "0.17.3"
 web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "spring_version" }
 graphql = { module = "org.springframework.boot:spring-boot-starter-graphql", version.ref = "spring_version" }
 webflux = { module = "org.springframework.boot:spring-boot-starter-webflux", version.ref = "spring_version" }
-aop = { module = "org.springframework.boot:spring-boot-starter-aop", version.ref = "spring_version" }
+aop = { module = "org.springframework.boot:spring-boot-starter-aspectj", version.ref = "spring_version" }
 actuator = { module = "org.springframework.boot:spring-boot-starter-actuator", version.ref = "spring_version" }
 devtools = { module = "org.springframework.boot:spring-boot-devtools", version.ref = "spring_version" }
 
 # Tests
 spring_test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "spring_version" }
 spring_graphql_test = { module = "org.springframework.graphql:spring-graphql-test", version.ref = "spring_graphql_test_version" }
-mockito = { module = "org.mockito:mockito-inline", version.ref = "mockito_version" }
+spring_boot_graphql_test = { module = "org.springframework.boot:spring-boot-graphql-test", version.ref = "spring_version" }
+mockito = { module = "org.mockito:mockito-core", version.ref = "mockito_version" }
 archunit = { module = "com.tngtech.archunit:archunit", version.ref = "archunit_version" }
 konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist_version" }
 kotlin_mockito = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "kotlin_mockito_version" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,13 @@
 [versions]
 spring_version = "4.1.0"
-spring_dependency_version = "1.1.7"
+# Kept separate from spring_version so Dependabot can bump the plugin
+# independently of the library modules (see dependabot-core#6990).
+spring_boot_plugin_version = "4.1.0"
 mockk_version = "1.14.11"
 spring_mockk_version = "5.0.1"
 spring_graphql_test_version = "2.0.4"
 kotlin_version = "2.4.0"
-kotlin_logging_version = "3.0.5"
+kotlin_logging_version = "8.0.4"
 mockito_version = "5.23.0"
 archunit_version = "1.4.2"
 kotlin_mockito_version = "6.3.0"
@@ -20,6 +22,9 @@ aop = { module = "org.springframework.boot:spring-boot-starter-aspectj", version
 actuator = { module = "org.springframework.boot:spring-boot-starter-actuator", version.ref = "spring_version" }
 devtools = { module = "org.springframework.boot:spring-boot-devtools", version.ref = "spring_version" }
 
+# Spring Boot BOM, imported as a Gradle platform (replaces io.spring.dependency-management)
+spring_boot_bom = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring_version" }
+
 # Tests
 spring_test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "spring_version" }
 spring_graphql_test = { module = "org.springframework.graphql:spring-graphql-test", version.ref = "spring_graphql_test_version" }
@@ -32,7 +37,7 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk_version" }
 spring_mockk = { module = "com.ninja-squad:springmockk", version.ref = "spring_mockk_version" }
 
 # Kotlin
-kotlin_logging = { module = "io.github.microutils:kotlin-logging", version.ref = "kotlin_logging_version" }
+kotlin_logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin_logging_version" }
 
 [bundles]
 defaultService = ["kotlin_logging", "aop", "devtools", "actuator", "web"]
@@ -45,6 +50,5 @@ konsist = ["konsist"]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin_version" }
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin_version" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin_version" }
-springframework = { id = "org.springframework.boot", version.ref = "spring_version" }
-spring-dependency = { id = "io.spring.dependency-management", version.ref = "spring_dependency_version" }
+springframework = { id = "org.springframework.boot", version.ref = "spring_boot_plugin_version" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint_gradle_version" }


### PR DESCRIPTION
## Summary

Upgrades the project from **Spring Boot 3.5.16 → 4.1.0** (Spring Framework 7) and applies the related cleanups it unlocks. Dependabot cannot propose the Boot bump on its own: `spring_version` is a shared version-catalog key referenced by **both** the `org.springframework.boot` plugin id **and** six library modules, which trips Dependabot's documented multi-dependency-property limitation on major bumps ([dependabot-core#6990](https://github.com/dependabot/dependabot-core/issues/6990)).

`./gradlew clean build` passes (58 tasks), including all GraphQL slice tests.

## Boot 4 / Framework 7 migrations required

| Breakage | Fix |
|---|---|
| `spring-boot-starter-aop` removed in Boot 4 | renamed to `spring-boot-starter-aspectj` |
| `@GraphQlTest` slice relocated & no longer transitive via `starter-test` | added `spring-boot-graphql-test`; import moved to `org.springframework.boot.graphql.test.autoconfigure` |
| `HttpHeaders` no longer implements `Map` (Framework 7) | `toSingleValueMap()` instead of Kotlin `mapValues` |
| Boot 4 defaults to Jackson 3; Jackson 2 codecs cause `NoClassDefFoundError` at runtime | migrated `GraphQlTester` codecs to `JacksonJson{Encoder,Decoder}` |
| `mockito-inline` discontinued | switched to `mockito-core` 5.23.0 (inline mock maker is default since Mockito 5) |

## Follow-up cleanups (included in this PR)

1. **Split the Boot plugin version key** — `spring_boot_plugin_version` is now separate from the `spring_version` library key, so Dependabot can bump future Boot majors independently and avoid dependabot-core#6990.
2. **Dropped `io.spring.dependency-management`** in favour of Gradle-native BOM support — `spring-boot-dependencies` is imported as a `platform(...)` on `implementation`/`testImplementation` in the `subprojects` block (Boot 4's recommended approach, faster builds).
3. **Replaced abandoned `io.github.microutils:kotlin-logging` 3.0.5** with its maintained successor `io.github.oshai:kotlin-logging-jvm` 8.0.4; the facade moved from the `mu` package to `io.github.oshai.kotlinlogging` (16 imports updated).

## Already Boot-4-ready (no change needed)

- `spring-graphql-test` 2.0.4 — Boot 4.1.0 manages exactly this version
- `springmockk` 5.0.1 — already the Framework 7 / Boot 4 line
- JDK 21, Kotlin 2.4.0, Gradle 9.6.1 — all satisfy Boot 4 baselines