### PR TITLE
feat(architecture): forbid services from using other use-cases

### DIFF
--- a/examples/architecture-combined/src/main/kotlin/de/emaarco/architecture/HexagonalArchitectureTest.kt
+++ b/examples/architecture-combined/src/main/kotlin/de/emaarco/architecture/HexagonalArchitectureTest.kt
@@ -1,5 +1,6 @@
 package de.emaarco.architecture
 
+import com.tngtech.archunit.core.domain.JavaClass.Predicates.INTERFACES
 import com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage
 import com.tngtech.archunit.core.importer.ClassFileImporter
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests
@@ -170,6 +171,23 @@ abstract class HexagonalArchitectureTest(
                 .resideInAPackage("..application.service..")
                 .because("Application services should not depend on each other")
                 .check(productionClasses)
+        }
+
+        @Test
+        fun `application service should not use any inbound port`() {
+            ArchRuleDefinition
+                .noClasses()
+                .that()
+                .resideInAPackage("..application.service..")
+                .should()
+                .accessClassesThat(
+                    resideInAPackage("..application.port.inbound..").and(INTERFACES),
+                ).because(
+                    "A service implements its own use-case but must never call or instantiate another " +
+                        "use-case; only the inbound *port interfaces* are forbidden ('access' = method " +
+                        "and constructor calls), so a service may still use its own use-case's nested " +
+                        "Command / Query data types",
+                ).check(productionClasses)
         }
     }
 

--- a/examples/architecture-combined/src/main/kotlin/de/emaarco/architecture/HexagonalArchitectureTest.kt
+++ b/examples/architecture-combined/src/main/kotlin/de/emaarco/architecture/HexagonalArchitectureTest.kt
@@ -182,12 +182,8 @@ abstract class HexagonalArchitectureTest(
                 .should()
                 .accessClassesThat(
                     resideInAPackage("..application.port.inbound..").and(INTERFACES),
-                ).because(
-                    "A service implements its own use-case but must never call or instantiate another " +
-                        "use-case; only the inbound *port interfaces* are forbidden ('access' = method " +
-                        "and constructor calls), so a service may still use its own use-case's nested " +
-                        "Command / Query data types",
-                ).check(productionClasses)
+                ).because("A service may implement its own use-case but must never call another one")
+                .check(productionClasses)
         }
     }
 

--- a/examples/archunit/src/main/kotlin/de/emaarco/archunit/HexagonalArchitectureTest.kt
+++ b/examples/archunit/src/main/kotlin/de/emaarco/archunit/HexagonalArchitectureTest.kt
@@ -1,5 +1,6 @@
 package de.emaarco.archunit
 
+import com.tngtech.archunit.core.domain.JavaClass.Predicates.INTERFACES
 import com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage
 import com.tngtech.archunit.core.importer.ClassFileImporter
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests
@@ -167,6 +168,23 @@ abstract class HexagonalArchitectureTest(
                 .resideInAPackage("..application.service..")
                 .because("Application services should not depend on each other")
                 .check(productionClasses)
+        }
+
+        @Test
+        fun `application service should not use any inbound port`() {
+            ArchRuleDefinition
+                .noClasses()
+                .that()
+                .resideInAPackage("..application.service..")
+                .should()
+                .accessClassesThat(
+                    resideInAPackage("..application.port.inbound..").and(INTERFACES),
+                ).because(
+                    "A service implements its own use-case but must never call or instantiate another " +
+                        "use-case; only the inbound *port interfaces* are forbidden ('access' = method " +
+                        "and constructor calls), so a service may still use its own use-case's nested " +
+                        "Command / Query data types",
+                ).check(productionClasses)
         }
     }
 

--- a/examples/archunit/src/main/kotlin/de/emaarco/archunit/HexagonalArchitectureTest.kt
+++ b/examples/archunit/src/main/kotlin/de/emaarco/archunit/HexagonalArchitectureTest.kt
@@ -179,12 +179,8 @@ abstract class HexagonalArchitectureTest(
                 .should()
                 .accessClassesThat(
                     resideInAPackage("..application.port.inbound..").and(INTERFACES),
-                ).because(
-                    "A service implements its own use-case but must never call or instantiate another " +
-                        "use-case; only the inbound *port interfaces* are forbidden ('access' = method " +
-                        "and constructor calls), so a service may still use its own use-case's nested " +
-                        "Command / Query data types",
-                ).check(productionClasses)
+                ).because("A service may implement its own use-case but must never call another one")
+                .check(productionClasses)
         }
     }
 

--- a/examples/archunit/src/test/kotlin/de/emaarco/archunit/ServiceInboundPortAccessTest.kt
+++ b/examples/archunit/src/test/kotlin/de/emaarco/archunit/ServiceInboundPortAccessTest.kt
@@ -1,0 +1,50 @@
+package de.emaarco.archunit
+
+import com.tngtech.archunit.core.domain.JavaClass.Predicates.INTERFACES
+import com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Demonstrates that the `application service should not use any inbound port` rule from
+ * [HexagonalArchitectureTest] actually fires — it is not enough that the two clean example services
+ * pass; we want a service that *provably* violates the rule.
+ *
+ * The fixture under `de.emaarco.archunit.example` is a tiny third example service:
+ * - `RegisterUserService` implements its own use case and only reads its own nested command -> allowed
+ * - `PromoteUserService`  implements its own use case but *calls* another use case           -> rejected
+ *
+ * The rule below mirrors the production rule verbatim (same `accessClassesThat` predicate that
+ * targets only the inbound *port interfaces*, not their command/query data types).
+ */
+class ServiceInboundPortAccessTest {
+
+    private val fixture = ClassFileImporter().importPackages("de.emaarco.archunit.example")
+
+    private val rule =
+        ArchRuleDefinition
+            .noClasses()
+            .that()
+            .resideInAPackage("..application.service..")
+            .should()
+            .accessClassesThat(
+                resideInAPackage("..application.port.inbound..").and(INTERFACES),
+            )
+
+    @Test
+    fun `rejects a service that calls another use-case`() {
+        val result = rule.evaluate(fixture)
+        val details = result.failureReport.details.joinToString(separator = "\n")
+        assertThat(result.hasViolation()).isTrue()
+        assertThat(details).contains("PromoteUserService")
+    }
+
+    @Test
+    fun `accepts a service that only implements its own use-case`() {
+        val result = rule.evaluate(fixture)
+        val details = result.failureReport.details.joinToString(separator = "\n")
+        assertThat(details).doesNotContain("RegisterUserService")
+    }
+}

--- a/examples/archunit/src/test/kotlin/de/emaarco/archunit/example/application/port/inbound/PromoteUserUseCase.kt
+++ b/examples/archunit/src/test/kotlin/de/emaarco/archunit/example/application/port/inbound/PromoteUserUseCase.kt
@@ -1,0 +1,10 @@
+package de.emaarco.archunit.example.application.port.inbound
+
+/** Inbound port of the third example service — a second state-changing use case with its own command. */
+interface PromoteUserUseCase {
+    fun promote(command: Command)
+
+    data class Command(
+        val name: String,
+    )
+}

--- a/examples/archunit/src/test/kotlin/de/emaarco/archunit/example/application/port/inbound/RegisterUserUseCase.kt
+++ b/examples/archunit/src/test/kotlin/de/emaarco/archunit/example/application/port/inbound/RegisterUserUseCase.kt
@@ -1,0 +1,10 @@
+package de.emaarco.archunit.example.application.port.inbound
+
+/** Inbound port of the third example service — a state-changing use case with its own command. */
+interface RegisterUserUseCase {
+    fun register(command: Command)
+
+    data class Command(
+        val name: String,
+    )
+}

--- a/examples/archunit/src/test/kotlin/de/emaarco/archunit/example/application/port/outbound/UserRepository.kt
+++ b/examples/archunit/src/test/kotlin/de/emaarco/archunit/example/application/port/outbound/UserRepository.kt
@@ -1,0 +1,6 @@
+package de.emaarco.archunit.example.application.port.outbound
+
+/** Outbound port of the third example service — a service is allowed to access this. */
+interface UserRepository {
+    fun save(name: String)
+}

--- a/examples/archunit/src/test/kotlin/de/emaarco/archunit/example/application/service/PromoteUserService.kt
+++ b/examples/archunit/src/test/kotlin/de/emaarco/archunit/example/application/service/PromoteUserService.kt
@@ -1,0 +1,19 @@
+package de.emaarco.archunit.example.application.service
+
+import de.emaarco.archunit.example.application.port.inbound.PromoteUserUseCase
+import de.emaarco.archunit.example.application.port.inbound.RegisterUserUseCase
+
+/**
+ * NEGATIVE case: implements its own use case but calls another one — rejected.
+ *
+ * It invokes [RegisterUserUseCase.register] on an injected inbound port. The rule forbids accessing
+ * inbound *port interfaces* (not their command/query data types), and that call targets a port
+ * interface, so this class is flagged.
+ */
+class PromoteUserService(
+    private val registerUser: RegisterUserUseCase,
+) : PromoteUserUseCase {
+    override fun promote(command: PromoteUserUseCase.Command) {
+        registerUser.register(RegisterUserUseCase.Command(command.name))
+    }
+}

--- a/examples/archunit/src/test/kotlin/de/emaarco/archunit/example/application/service/RegisterUserService.kt
+++ b/examples/archunit/src/test/kotlin/de/emaarco/archunit/example/application/service/RegisterUserService.kt
@@ -1,0 +1,20 @@
+package de.emaarco.archunit.example.application.service
+
+import de.emaarco.archunit.example.application.port.inbound.RegisterUserUseCase
+import de.emaarco.archunit.example.application.port.outbound.UserRepository
+
+/**
+ * POSITIVE case: implements its own use case and never calls another one — allowed.
+ *
+ * It only reaches out through an *outbound* port and reads the getters of its own nested
+ * [RegisterUserUseCase.Command]. The rule forbids accessing inbound *port interfaces* (not their
+ * command/query data types), and implementing [RegisterUserUseCase] is inheritance rather than
+ * access, so this class is left alone.
+ */
+class RegisterUserService(
+    private val userRepository: UserRepository,
+) : RegisterUserUseCase {
+    override fun register(command: RegisterUserUseCase.Command) {
+        userRepository.save(command.name)
+    }
+}


### PR DESCRIPTION
## What

Adds an ArchUnit rule (in both the `archunit` and `architecture-combined` modules) enforcing that an **application service implements its own use-case but never calls or instantiates another one** — "inherit one use-case, use none".

```kotlin
noClasses().that().resideInAPackage("..application.service..")
    .should().accessClassesThat(
        resideInAPackage("..application.port.inbound..").and(INTERFACES),
    )
    .because("A service may implement its own use-case but must never call another one")
```

## Why the predicate looks like this

- **`accessClassesThat`** (method + constructor calls) captures "uses a use-case" while *ignoring the implements-relationship* of the service's own port — that distinction is exactly what makes "erben erlaubt, nutzen verboten" expressible as a single property.
- **`.and(INTERFACES)`** is essential: without it the rule false-positives on a service reading the getters of its *own* use-case's nested `Command`/`Query` data types (real hit surfaced during development: `AddTaskService.buildTask` reading `AddTaskUseCase.Command`).
- Konsist has no `access`-level equivalent (source-only), so this rule is ArchUnit-only.

## Proof it actually fires

New self-test under `examples/archunit/src/test`:
- a tiny third example hexagon at `de.emaarco.archunit.example.application.*`
  - `RegisterUserService` — implements its own use-case, reads its own `Command` → **allowed**
  - `PromoteUserService` — implements its own use-case but calls `RegisterUserUseCase.register` → **rejected**
- `ServiceInboundPortAccessTest` evaluates the rule and asserts the violating class is reported and the clean one is not (also a regression guard for the Command false-positive).

## Verification

`./gradlew ktlintCheck test` — green across all modules; the two existing example services still pass (they run the new rule transitively).