### PR TITLE
test: add integration tests to de-risk dependabot updates

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,24 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+run_mode = "nonconcurrent"
+
+# --- Boot an app ---------------------------------------------------------
+
+[scripts.run.app-headers]
+command = "./gradlew :examples:spring-for-graphql-http-headers:bootRun"
+icon = "server"
+
+[scripts.run.app-fragments]
+command = "./gradlew :examples:spring-for-graphql-fragment-source:bootRun"
+icon = "server"
+
+# --- Run the Bruno e2e smoke tests against a running app -----------------
+
+[scripts.run.smoke-headers]
+command = "cd examples/spring-for-graphql-http-headers/bruno && npx --yes @usebruno/cli run . --env Local"
+icon = "test-tube"
+
+[scripts.run.smoke-fragments]
+command = "cd examples/spring-for-graphql-fragment-source/bruno && npx --yes @usebruno/cli run . --env Local"
+icon = "test-tube"

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -66,10 +66,12 @@ jobs:
       - name: Start application
         run: nohup ./gradlew :examples:${{ matrix.module }}:bootRun > app.log 2>&1 &
 
-      # Step 6: Wait until the app reports healthy (poll /actuator/health)
+      # Step 6: Wait until the app reports healthy (poll /actuator/health).
+      #         The e2e job runs with a cold Gradle cache, so the first bootRun
+      #         also compiles the module - allow a generous budget (90 x 2s).
       - name: Wait for health
         run: |
-          for i in $(seq 1 60); do
+          for i in $(seq 1 90); do
             if curl -sf "http://localhost:${{ matrix.port }}/actuator/health" | grep -q '"status":"UP"'; then
               echo "Application is up"
               exit 0
@@ -90,3 +92,17 @@ jobs:
       - name: Dump application log on failure
         if: failure()
         run: cat app.log
+
+      # Step 9: Always stop the background app so it never lingers on the runner.
+      #         bootRun forks a separate JVM via the Gradle daemon, so we kill by
+      #         port rather than by the launcher PID.
+      - name: Stop application
+        if: always()
+        run: |
+          pid=$(lsof -ti tcp:${{ matrix.port }} || true)
+          if [ -n "$pid" ]; then
+            echo "Stopping application (pid $pid)"
+            kill $pid || true
+          else
+            echo "No application process to stop"
+          fi

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -18,13 +18,75 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      # Step 3: Set up JDK 21
-      - name: Set up JDK 21
+      # Step 3: Set up JDK 25
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
 
       # Step 4: Run Gradle build
       - name: Run Gradle Build
         run: ./gradlew build
+
+  e2e:
+    name: E2E (Bruno) - ${{ matrix.module }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { module: spring-for-graphql-http-headers, port: 8081 }
+          - { module: spring-for-graphql-fragment-source, port: 8082 }
+
+    steps:
+      # Step 1: Checkout code
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      # Step 2: Setup Gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      # Step 3: Set up JDK 25
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      # Step 4: Set up Node (for the Bruno CLI via npx)
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Step 5: Boot the Spring app in the background
+      - name: Start application
+        run: nohup ./gradlew :examples:${{ matrix.module }}:bootRun > app.log 2>&1 &
+
+      # Step 6: Wait until the app reports healthy (poll /actuator/health)
+      - name: Wait for health
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf "http://localhost:${{ matrix.port }}/actuator/health" | grep -q '"status":"UP"'; then
+              echo "Application is up"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Application did not become healthy in time"
+          cat app.log
+          exit 1
+
+      # Step 7: Run the Bruno end-to-end collection against the running app
+      #         (the CLI must be invoked from the collection root)
+      - name: Run Bruno e2e tests
+        working-directory: examples/${{ matrix.module }}/bruno
+        run: npx --yes @usebruno/cli run . --env Local
+
+      # Step 8: Surface the application log if anything above failed
+      - name: Dump application log on failure
+        if: failure()
+        run: cat app.log

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -66,9 +66,7 @@ jobs:
       - name: Start application
         run: nohup ./gradlew :examples:${{ matrix.module }}:bootRun > app.log 2>&1 &
 
-      # Step 6: Wait until the app reports healthy (poll /actuator/health).
-      #         The e2e job runs with a cold Gradle cache, so the first bootRun
-      #         also compiles the module - allow a generous budget (90 x 2s).
+      # Step 6: Poll /actuator/health until UP (generous budget - cold cache means the first bootRun also compiles)
       - name: Wait for health
         run: |
           for i in $(seq 1 90); do
@@ -82,8 +80,7 @@ jobs:
           cat app.log
           exit 1
 
-      # Step 7: Run the Bruno end-to-end collection against the running app
-      #         (the CLI must be invoked from the collection root)
+      # Step 7: Run the Bruno end-to-end collection against the running app (CLI must run from the collection root)
       - name: Run Bruno e2e tests
         working-directory: examples/${{ matrix.module }}/bruno
         run: npx --yes @usebruno/cli run . --env Local
@@ -93,9 +90,7 @@ jobs:
         if: failure()
         run: cat app.log
 
-      # Step 9: Always stop the background app so it never lingers on the runner.
-      #         bootRun forks a separate JVM via the Gradle daemon, so we kill by
-      #         port rather than by the launcher PID.
+      # Step 9: Always stop the background app so it never lingers on the runner (kill by port, not launcher PID)
       - name: Stop application
         if: always()
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,14 +61,14 @@ subprojects {
 
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(21))
+            languageVersion.set(JavaLanguageVersion.of(25))
         }
     }
 
     tasks.withType<KotlinCompile>().configureEach {
         println("Configuring $name in project ${project.name}...")
         compilerOptions {
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_25)
             freeCompilerArgs.add("-Xjsr305=strict")
         }
     }

--- a/examples/spring-for-graphql-fragment-source/bruno/Load Tasks.bru
+++ b/examples/spring-for-graphql-fragment-source/bruno/Load Tasks.bru
@@ -1,7 +1,7 @@
 meta {
-  name: Get Tasks
+  name: Load Tasks
   type: graphql
-  seq: 2
+  seq: 1
 }
 
 post {
@@ -29,12 +29,13 @@ tests {
   test("no GraphQL errors", function () {
     expect(res.body.errors).to.equal(undefined);
   });
-  test("the task created in the previous request is returned", function () {
-    const createdId = bru.getVar("createdTaskId");
+  test("returns the 5 tasks seeded at startup", function () {
     const tasks = res.body.data.tasks;
     expect(tasks).to.be.an("array");
-    const match = tasks.find(function (t) { return t.id === createdId; });
-    expect(match, "created task should be returned by the tasks query").to.not.equal(undefined);
-    expect(match.title).to.equal("test");
+    expect(tasks.length).to.equal(5);
+    const titles = tasks.map(function (t) { return t.title; });
+    for (let i = 1; i <= 5; i++) {
+      expect(titles, "should contain Task " + i).to.include("Task " + i);
+    }
   });
 }

--- a/examples/spring-for-graphql-fragment-source/bruno/bruno.json
+++ b/examples/spring-for-graphql-fragment-source/bruno/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "spring-for-graphql-fragment-source",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/examples/spring-for-graphql-fragment-source/bruno/environments/Local.bru
+++ b/examples/spring-for-graphql-fragment-source/bruno/environments/Local.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: http://localhost:8082
+}

--- a/examples/spring-for-graphql-fragment-source/src/main/resources/application.yml
+++ b/examples/spring-for-graphql-fragment-source/src/main/resources/application.yml
@@ -3,7 +3,15 @@ spring:
     graphiql:
       enabled: true
       path: /graphiql
-    path: /api/graphql
+    http:
+      path: /api/graphql
 
 server:
   port: 8082
+
+# Exposes /actuator/health so CI / Conductor can poll readiness before running e2e tests
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/examples/spring-for-graphql-fragment-source/src/main/resources/application.yml
+++ b/examples/spring-for-graphql-fragment-source/src/main/resources/application.yml
@@ -9,7 +9,6 @@ spring:
 server:
   port: 8082
 
-# Exposes /actuator/health so CI / Conductor can poll readiness before running e2e tests
 management:
   endpoints:
     web:

--- a/examples/spring-for-graphql-fragment-source/src/test/kotlin/de/emaarco/example/ApplicationSmokeTest.kt
+++ b/examples/spring-for-graphql-fragment-source/src/test/kotlin/de/emaarco/example/ApplicationSmokeTest.kt
@@ -1,0 +1,16 @@
+package de.emaarco.example
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * Boots the full Spring application context to catch dependency-upgrade breakage
+ * (bean wiring, autoconfiguration, GraphQL schema binding, and startup task seeding)
+ * that structural architecture tests cannot detect.
+ */
+@SpringBootTest
+class ApplicationSmokeTest {
+
+    @Test
+    fun contextLoads() {}
+}

--- a/examples/spring-for-graphql-http-headers/bruno/Create Task.bru
+++ b/examples/spring-for-graphql-http-headers/bruno/Create Task.bru
@@ -1,17 +1,17 @@
 meta {
   name: Create Task
   type: graphql
-  seq: 3
+  seq: 1
 }
 
 post {
-  url: http://localhost:8081/api/graphql
+  url: {{baseUrl}}/api/graphql
   body: graphql
   auth: none
 }
 
 headers {
-  x-user-id: user123
+  x-user-id: {{userId}}
 }
 
 body:graphql {
@@ -22,5 +22,25 @@ body:graphql {
       description
     }
   }
-  
+}
+
+script:post-response {
+  if (res.body.data && res.body.data.addTask) {
+    bru.setVar("createdTaskId", res.body.data.addTask.id);
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("no GraphQL errors", function () {
+    expect(res.body.errors).to.equal(undefined);
+  });
+  test("task is created and echoed back", function () {
+    expect(res.body.data.addTask.id).to.be.a("string");
+    expect(res.body.data.addTask.title).to.equal("test");
+    expect(res.body.data.addTask.description).to.equal("test2");
+  });
 }

--- a/examples/spring-for-graphql-http-headers/bruno/environments/Local.bru
+++ b/examples/spring-for-graphql-http-headers/bruno/environments/Local.bru
@@ -1,0 +1,4 @@
+vars {
+  baseUrl: http://localhost:8081
+  userId: user123
+}

--- a/examples/spring-for-graphql-http-headers/src/main/resources/application.yml
+++ b/examples/spring-for-graphql-http-headers/src/main/resources/application.yml
@@ -10,7 +10,6 @@ spring:
 server:
   port: 8081
 
-# Exposes /actuator/health so CI / Conductor can poll readiness before running e2e tests
 management:
   endpoints:
     web:

--- a/examples/spring-for-graphql-http-headers/src/main/resources/application.yml
+++ b/examples/spring-for-graphql-http-headers/src/main/resources/application.yml
@@ -4,7 +4,15 @@ spring:
     graphiql:
       enabled: true
       path: /graphiql
-    path: /api/graphql
+    http:
+      path: /api/graphql
 
 server:
   port: 8081
+
+# Exposes /actuator/health so CI / Conductor can poll readiness before running e2e tests
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/examples/spring-for-graphql-http-headers/src/test/kotlin/de/emaarco/example/ApplicationSmokeTest.kt
+++ b/examples/spring-for-graphql-http-headers/src/test/kotlin/de/emaarco/example/ApplicationSmokeTest.kt
@@ -1,0 +1,16 @@
+package de.emaarco.example
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * Boots the full Spring application context to catch dependency-upgrade breakage
+ * (bean wiring, autoconfiguration, GraphQL schema binding, the header interceptor
+ * and argument-resolver SPI) that structural architecture tests cannot detect.
+ */
+@SpringBootTest
+class ApplicationSmokeTest {
+
+    @Test
+    fun contextLoads() {}
+}


### PR DESCRIPTION
## Why

Dependabot bumps this repo's Gradle deps monthly (grouped, incl. **major**), but CI only ran `./gradlew build` and every test was **structural** (ArchUnit/Konsist parse *source*) — nothing booted Spring or exercised the Spring-for-GraphQL runtime. So a green build gave *false confidence* on an upgrade, and each Dependabot PR needed manual runtime re-checking.

This adds two complementary runtime safety nets so a green `pre-merge` = safe to merge.

## What

- **Context-load smoke tests** — `@SpringBootTest contextLoads()` for both apps (run inside `./gradlew build`). Catches wiring/autoconfig/schema-binding breakage.
- **Bruno e2e collections** — one per app, real HTTP against the running app with assertions (`bru run` exits non-zero on failure):
  - `http-headers` (8081): create task (with `x-user-id`) → load → assert the created task is returned.
  - `fragment-source` (8082): load → assert the 5 startup-seeded tasks.
- **CI** — new `e2e` matrix job in `pre-merge.yml`: boot app → poll `/actuator/health` → run the collection → dump app log on failure.
- **Conductor** — `.conductor/settings.toml` run targets to drive the apps + smoke tests locally, mirroring CI.
- **fix** — restore the configured GraphQL path via `spring.graphql.http.path`. Spring Boot 4 renamed `spring.graphql.path`, which had **silently** moved the endpoint from `/api/graphql` to the default `/graphql` (every `/api/graphql` client was getting a 404 while the build stayed green — exactly the breakage these tests are meant to surface).
- **build** — expose actuator `health` for readiness polling; bump the Java toolchain + CI to **Java 25**.

## Verification (local, on JDK 25)

- `./gradlew clean build` → BUILD SUCCESSFUL; both context tests pass.
- `http-headers` booted → `/api/graphql` 200 → Bruno **4/4 tests, 2/2 assertions PASS**.
- `fragment-source` booted → `/api/graphql` 200 → Bruno **2/2 tests, 1/1 assertion PASS**.

## Result for Dependabot

A green `pre-merge` now means the full context boots **and** the real GraphQL HTTP runtime, schema binding, header interceptor, and JSON encoding all work over the wire. Reviewing a Dependabot PR collapses to "is the check green."

Optional follow-up: add an `npm` ecosystem + auto-merge-on-green for patch/minor to `dependabot.yml` once the suite is trusted.