### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,17 @@ updates:
                     - "patch"
                     - "minor"
                     - "major"
+
+    # Config for GitHub Actions (keeps SHA pins and version comments fresh)
+    -   package-ecosystem: "github-actions"
+        directory: "/"
+        schedule:
+            interval: "monthly"
+        groups:
+            github-actions:
+                patterns:
+                    - "*"
+                update-types:
+                    - "patch"
+                    - "minor"
+                    - "major"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,12 +26,12 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@b76a0776ae74036e77cd11018083743453d7ad35 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -12,15 +12,15 @@ jobs:
     steps:
       # Step 1: Checkout code
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # Step 2: Setup Gradle
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
 
       # Step 3: Set up JDK 25
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -43,22 +43,22 @@ jobs:
     steps:
       # Step 1: Checkout code
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # Step 2: Setup Gradle
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
 
       # Step 3: Set up JDK 25
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '25'
           distribution: 'temurin'
 
       # Step 4: Set up Node (for the Bruno CLI via npx)
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 


### PR DESCRIPTION
## What

Pins **every** GitHub Actions reference (9 total, across `pre-merge.yml` and `claude.yml`) to a full-length commit SHA, keeping the original version as a trailing comment.

## Why

Mutable tags (`@v4`, `@v2`, `@v1`) can be silently repointed by whoever controls the upstream repo — exactly the [`tj-actions/changed-files` compromise (CVE-2025-30066)](https://github.com/tj-actions/changed-files/security/advisories), where existing tags were moved to a malicious commit that dumped CI secrets. Only SHA-pinned consumers were unaffected. SHA pinning is [GitHub-recommended hardening](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and the OpenSSF Scorecard `Pinned-Dependencies` check.

The two third-party actions (`gradle/gradle-build-action`, `anthropics/claude-code-action`) were the highest-risk items.

## Changes

| Action | Pinned SHA |
|---|---|
| `actions/checkout` | `11d5960` (v4) / `d23441a` (v6) |
| `gradle/gradle-build-action` | `a8f7551` (v2) |
| `actions/setup-java` | `c1e3236` (v4) |
| `actions/setup-node` | `49933ea` (v4) |
| `anthropics/claude-code-action` | `b76a077` (v1) |

Also adds a `github-actions` Dependabot ecosystem so pins + version comments stay fresh automatically.

## Note

`gradle/gradle-build-action` is deprecated upstream (superseded by `gradle/actions/setup-gradle`). This PR only pins the existing reference to stay surgical — a migration is worth a follow-up.